### PR TITLE
Merge performance and serialization changes

### DIFF
--- a/histogram_test.go
+++ b/histogram_test.go
@@ -14,27 +14,30 @@ func approx(x, y float64) bool {
 
 func TestHistogram(t *testing.T) {
 	h := NewHistogram(160)
-	for _, val := range testData {
-		h.Add(float64(val))
-	}
-	if h.Count() != 14999 {
-		t.Errorf("Expected h.Count() to be 14999, got %f", h.Count())
-	}
+	for i := 0; i < 30; i++ {
+		for _, val := range testData {
+			h.Add(float64(val))
+		}
+		if h.Count() != 14999 {
+			t.Errorf("Expected h.Count() to be 14999, got %f", h.Count())
+		}
 
-	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {
-		t.Errorf("Expected 25th percentile to be %v, got %v", 14, firstQ)
-	}
-	if median := h.Quantile(0.5); !approx(median, 18) {
-		t.Errorf("Expected 50th percentile to be %v, got %v", 18, median)
-	}
-	if thirdQ := h.Quantile(0.75); !approx(thirdQ, 22) {
-		t.Errorf("Expected 75th percentile to be %v, got %v", 22, thirdQ)
-	}
-	if cdf := h.CDF(18); !approx(cdf, 0.5) {
-		t.Errorf("Expected CDF(median) to be %v, got %v", 0.5, cdf)
-	}
-	if cdf := h.CDF(22); !approx(cdf, 0.75) {
-		t.Errorf("Expected CDF(3rd quartile) to be %v, got %v", 0.75, cdf)
+		if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {
+			t.Errorf("Expected 25th percentile to be %v, got %v", 14, firstQ)
+		}
+		if median := h.Quantile(0.5); !approx(median, 18) {
+			t.Errorf("Expected 50th percentile to be %v, got %v", 18, median)
+		}
+		if thirdQ := h.Quantile(0.75); !approx(thirdQ, 22) {
+			t.Errorf("Expected 75th percentile to be %v, got %v", 22, thirdQ)
+		}
+		if cdf := h.CDF(18); !approx(cdf, 0.5) {
+			t.Errorf("Expected CDF(median) to be %v, got %v", 0.5, cdf)
+		}
+		if cdf := h.CDF(22); !approx(cdf, 0.75) {
+			t.Errorf("Expected CDF(3rd quartile) to be %v, got %v", 0.75, cdf)
+		}
+		h.Reset()
 	}
 }
 

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -18,7 +18,7 @@ func TestHistogram(t *testing.T) {
 		h.Add(float64(val))
 	}
 	if h.Count() != 14999 {
-		t.Errorf("Expected h.Count() to be 100, got ", h.Count())
+		t.Errorf("Expected h.Count() to be 14999, got %f", h.Count())
 	}
 
 	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -27,7 +27,7 @@ func NewHistogram(n int) *NumericHistogram {
 
 func (h *NumericHistogram) Reset() {
 	h.total = 0
-	h.bins = h.bins[:1]
+	h.bins = h.bins[:0]
 }
 
 func (h *NumericHistogram) Add(n float64) {

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -25,13 +25,13 @@ func NewHistogram(n int) *NumericHistogram {
 func (h *NumericHistogram) Add(n float64) {
 	defer h.trim()
 	h.total++
-	for i := range h.bins {
-		if h.bins[i].value == n {
+	for i, bini := range h.bins {
+		if bini.value == n {
 			h.bins[i].count++
 			return
 		}
 
-		if h.bins[i].value > n {
+		if bini.value > n {
 
 			newbin := bin{value: n, count: 1}
 			tail := h.bins[i:]
@@ -113,24 +113,27 @@ func (h *NumericHistogram) trim() {
 		// Find closest bins in terms of value
 		minDelta := 1e99
 		minDeltaIndex := 0
-		for i := range h.bins {
+		for i, bini := range h.bins {
 			if i == 0 {
 				continue
 			}
 
-			if delta := h.bins[i].value - h.bins[i-1].value; delta < minDelta {
+			if delta := bini.value - h.bins[i-1].value; delta < minDelta {
 				minDelta = delta
 				minDeltaIndex = i
 			}
 		}
 
+		binMinDeltaIdxSub1 := h.bins[minDeltaIndex-1]
+		binMinDeltaIdx := h.bins[minDeltaIndex]
+
 		// We need to merge bins minDeltaIndex-1 and minDeltaIndex
-		totalCount := h.bins[minDeltaIndex-1].count + h.bins[minDeltaIndex].count
+		totalCount := binMinDeltaIdxSub1.count + binMinDeltaIdx.count
 		mergedbin := bin{
-			value: (h.bins[minDeltaIndex-1].value*
-				h.bins[minDeltaIndex-1].count +
-				h.bins[minDeltaIndex].value*
-					h.bins[minDeltaIndex].count) /
+			value: (binMinDeltaIdxSub1.value*
+				binMinDeltaIdxSub1.count +
+				binMinDeltaIdx.value*
+					binMinDeltaIdx.count) /
 				totalCount, // weighted average
 			count: totalCount, // summed heights
 		}

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -25,21 +25,25 @@ func NewHistogram(n int) *NumericHistogram {
 	}
 }
 
+func (h *NumericHistogram) Reset() {
+	h.total = 0
+	h.bins = h.bins[:1]
+}
+
 func (h *NumericHistogram) Add(n float64) {
 	h.total++
 	for i, bini := range h.bins {
 		if bini.value == n {
 			h.bins[i].count++
-			h.trim()
 			return
 		}
 
 		if bini.value > n {
-			newbin := bin{value: n, count: 1}
+			// Insert a bin at i
 			tail := h.bins[i:]
 			h.bins = h.bins[0 : len(h.bins)+1]
 			copy(h.bins[i+1:], tail)
-			h.bins[i] = newbin
+			h.bins[i] = bin{value: n, count: 1}
 
 			h.trim()
 			return
@@ -144,11 +148,13 @@ func (h *NumericHistogram) trim() {
 				totalCount, // weighted average
 			count: totalCount, // summed heights
 		}
+
+		// Now remove bin minDeltaIndex by replacing minDeltaIndex-1 with mergedbin
 		head := h.bins[0:minDeltaIndex]
 		tail := h.bins[minDeltaIndex+1:]
 		head[minDeltaIndex-1] = mergedbin
 		copy(h.bins[minDeltaIndex:], tail)
-		h.bins = h.bins[:h.maxbins]
+		h.bins = h.bins[:len(h.bins)-1]
 	}
 }
 

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -136,8 +136,8 @@ func (h *NumericHistogram) trim() {
 		}
 		head := h.bins[0:minDeltaIndex]
 		tail := h.bins[minDeltaIndex+1:]
-		head[minDeltaIndex] = mergedbin
-		copy(h.bins[minDeltaIndex+1:], tail)
+		head[minDeltaIndex-1] = mergedbin
+		copy(h.bins[minDeltaIndex:], tail)
 		h.bins = h.bins[:h.maxbins]
 	}
 }

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -113,16 +113,19 @@ func (h *NumericHistogram) Count() float64 {
 
 // trim merges adjacent bins to decrease the bin count to the maximum value
 func (h *NumericHistogram) trim() {
+	if len(h.bins) <= 1 {
+		return
+	}
 	for len(h.bins) > h.maxbins {
 		// Find closest bins in terms of value
-		minDelta := 1e99
-		minDeltaIndex := 0
-		for i, bini := range h.bins {
-			if i == 0 {
+		minDelta := h.bins[1].value - h.bins[0].value
+		minDeltaIndex := 1
+		for i := 2; i < len(h.bins); i++ {
+			if i <= 1 {
 				continue
 			}
 
-			if delta := bini.value - h.bins[i-1].value; delta < minDelta {
+			if delta := h.bins[i].value - h.bins[i-1].value; delta < minDelta {
 				minDelta = delta
 				minDeltaIndex = i
 			}

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -16,7 +16,7 @@ type NumericHistogram struct {
 // should be sufficient.
 func NewHistogram(n int) *NumericHistogram {
 	return &NumericHistogram{
-		bins:    make([]bin, 0),
+		bins:    make([]bin, 0, n+1),
 		maxbins: n,
 		total:   0,
 	}
@@ -34,11 +34,11 @@ func (h *NumericHistogram) Add(n float64) {
 		if h.bins[i].value > n {
 
 			newbin := bin{value: n, count: 1}
-			head := append(make([]bin, 0), h.bins[0:i]...)
-
-			head = append(head, newbin)
 			tail := h.bins[i:]
-			h.bins = append(head, tail...)
+			h.bins = h.bins[0 : len(h.bins)+1]
+			copy(h.bins[i+1:], tail)
+			h.bins[i] = newbin
+
 			return
 		}
 	}
@@ -134,9 +134,11 @@ func (h *NumericHistogram) trim() {
 				totalCount, // weighted average
 			count: totalCount, // summed heights
 		}
-		head := append(make([]bin, 0), h.bins[0:minDeltaIndex-1]...)
-		tail := append([]bin{mergedbin}, h.bins[minDeltaIndex+1:]...)
-		h.bins = append(head, tail...)
+		head := h.bins[0:minDeltaIndex]
+		tail := h.bins[minDeltaIndex+1:]
+		head[minDeltaIndex] = mergedbin
+		copy(h.bins[minDeltaIndex+1:], tail)
+		h.bins = h.bins[:h.maxbins]
 	}
 }
 

--- a/numerichistogram.go
+++ b/numerichistogram.go
@@ -26,27 +26,28 @@ func NewHistogram(n int) *NumericHistogram {
 }
 
 func (h *NumericHistogram) Add(n float64) {
-	defer h.trim()
 	h.total++
 	for i, bini := range h.bins {
 		if bini.value == n {
 			h.bins[i].count++
+			h.trim()
 			return
 		}
 
 		if bini.value > n {
-
 			newbin := bin{value: n, count: 1}
 			tail := h.bins[i:]
 			h.bins = h.bins[0 : len(h.bins)+1]
 			copy(h.bins[i+1:], tail)
 			h.bins[i] = newbin
 
+			h.trim()
 			return
 		}
 	}
 
 	h.bins = append(h.bins, bin{count: 1, value: n})
+	h.trim()
 }
 
 func (h *NumericHistogram) Quantile(q float64) float64 {

--- a/numerichistogram_test.go
+++ b/numerichistogram_test.go
@@ -1,0 +1,30 @@
+package gohistogram
+
+import (
+	"testing"
+	"math/rand"
+)
+
+func BenchmarkNumericHistogram20(b *testing.B) {
+	runBenchmark(20, b.N)
+//	b.Logf("median: %f", h.Quantile(.50) )
+}
+
+func BenchmarkNumericHistogram50(b *testing.B) {
+	runBenchmark(50, b.N)
+//	b.Logf("median: %f", h.Quantile(.50) )
+}
+
+func BenchmarkNumericHistogram100(b *testing.B) {
+	runBenchmark(100, b.N)
+//	b.Logf("median: %f", h.Quantile(.50) )
+}
+
+func runBenchmark(maxSize int, iterSize int) *NumericHistogram {
+	h := NewHistogram(maxSize)
+	r := rand.New(rand.NewSource(0))
+	for i := 0; i < iterSize; i++ {
+		h.Add(r.Float64())
+	}
+	return h
+}

--- a/serialize.go
+++ b/serialize.go
@@ -26,7 +26,7 @@ func NewHistogramBytes(buff []byte) *NumericHistogram {
 	total = binary.LittleEndian.Uint64(buff)
 	maxbins = int(binary.LittleEndian.Uint64(buff[8:]))
 	lbins = int(binary.LittleEndian.Uint64(buff[16:]))
-	bins := make([]bin, lbins)
+	bins := make([]bin, lbins, maxbins+1)
 	for i, p := 0, 24; i < lbins; i, p = i+1, p+16 {
 		bins[i] = bin{
 			value: math.Float64frombits(binary.LittleEndian.Uint64(buff[p:])),

--- a/serialize.go
+++ b/serialize.go
@@ -1,0 +1,80 @@
+package gohistogram
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+func (h *NumericHistogram) Bytes() []byte {
+	b := make([]byte, 2*8*len(h.bins)+8+8+8)
+	binary.LittleEndian.PutUint64(b, h.total)
+	binary.LittleEndian.PutUint64(b[8:], uint64(h.maxbins))
+	binary.LittleEndian.PutUint64(b[16:], uint64(len(h.bins)))
+	p := 24
+	for _, v := range h.bins {
+		binary.LittleEndian.PutUint64(b[p:], math.Float64bits(v.value))
+		binary.LittleEndian.PutUint64(b[p+8:], math.Float64bits(v.count))
+		p += 16
+	}
+	return b
+}
+
+func NewHistogramBytes(buff []byte) *NumericHistogram {
+	var total uint64
+	var maxbins int
+	var lbins int
+	total = binary.LittleEndian.Uint64(buff)
+	maxbins = int(binary.LittleEndian.Uint64(buff[8:]))
+	lbins = int(binary.LittleEndian.Uint64(buff[16:]))
+	bins := make([]bin, lbins)
+	for i, p := 0, 24; i < lbins; i, p = i+1, p+16 {
+		bins[i] = bin{
+			value: math.Float64frombits(binary.LittleEndian.Uint64(buff[p:])),
+			count: math.Float64frombits(binary.LittleEndian.Uint64(buff[p+8:])),
+		}
+	}
+	return &NumericHistogram{
+		bins:    bins,
+		maxbins: maxbins,
+		total:   total,
+	}
+}
+
+func (h *WeightedHistogram) Bytes() []byte {
+	b := make([]byte, 2*8*len(h.bins)+8+8+8+8)
+	binary.LittleEndian.PutUint64(b, math.Float64bits(h.total))
+	binary.LittleEndian.PutUint64(b[8:], uint64(h.maxbins))
+	binary.LittleEndian.PutUint64(b[16:], uint64(len(h.bins)))
+	binary.LittleEndian.PutUint64(b[24:], math.Float64bits(h.alpha))
+	p := 32
+	for _, v := range h.bins {
+		binary.LittleEndian.PutUint64(b[p:], math.Float64bits(v.value))
+		binary.LittleEndian.PutUint64(b[p+8:], math.Float64bits(v.count))
+		p += 16
+	}
+	return b
+}
+
+func NewWeightedHistogramBytes(buff []byte) *WeightedHistogram {
+	var total float64
+	var maxbins int
+	var lbins int
+	var alpha float64
+	total = math.Float64frombits(binary.LittleEndian.Uint64(buff))
+	maxbins = int(binary.LittleEndian.Uint64(buff[8:]))
+	lbins = int(binary.LittleEndian.Uint64(buff[16:]))
+	alpha = math.Float64frombits(binary.LittleEndian.Uint64(buff[24:]))
+	bins := make([]bin, lbins)
+	for i, p := 0, 32; i < lbins; i, p = i+1, p+16 {
+		bins[i] = bin{
+			value: math.Float64frombits(binary.LittleEndian.Uint64(buff[p:])),
+			count: math.Float64frombits(binary.LittleEndian.Uint64(buff[p+8:])),
+		}
+	}
+	return &WeightedHistogram{
+		bins:    bins,
+		maxbins: maxbins,
+		total:   total,
+		alpha:   alpha,
+	}
+}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,0 +1,57 @@
+package gohistogram
+
+import (
+	"testing"
+)
+
+func TestHistogramBytes(t *testing.T) {
+	h := NewHistogram(160)
+	for _, val := range testData {
+		h.Add(float64(val))
+	}
+	bq := h.Bytes()
+	h = NewHistogramBytes(bq)
+	if h.Count() != 14999 {
+		t.Errorf("Expected h.Count() to be 100, got ", h.Count())
+	}
+
+	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {
+		t.Errorf("Expected 25th percentile to be %v, got %v", 14, firstQ)
+	}
+	if median := h.Quantile(0.5); !approx(median, 18) {
+		t.Errorf("Expected 50th percentile to be %v, got %v", 18, median)
+	}
+	if thirdQ := h.Quantile(0.75); !approx(thirdQ, 22) {
+		t.Errorf("Expected 75th percentile to be %v, got %v", 22, thirdQ)
+	}
+	if cdf := h.CDF(18); !approx(cdf, 0.5) {
+		t.Errorf("Expected CDF(median) to be %v, got %v", 0.5, cdf)
+	}
+	if cdf := h.CDF(22); !approx(cdf, 0.75) {
+		t.Errorf("Expected CDF(3rd quartile) to be %v, got %v", 0.75, cdf)
+	}
+}
+
+func TestWeightedHistogramBytes(t *testing.T) {
+	h := NewWeightedHistogram(160, 1)
+	for _, val := range testData {
+		h.Add(float64(val))
+	}
+	bq := h.Bytes()
+	h = NewWeightedHistogramBytes(bq)
+	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {
+		t.Errorf("Expected 25th percentile to be %v, got %v", 14, firstQ)
+	}
+	if median := h.Quantile(0.5); !approx(median, 18) {
+		t.Errorf("Expected 50th percentile to be %v, got %v", 18, median)
+	}
+	if thirdQ := h.Quantile(0.75); !approx(thirdQ, 22) {
+		t.Errorf("Expected 75th percentile to be %v, got %v", 22, thirdQ)
+	}
+	if cdf := h.CDF(18); !approx(cdf, 0.5) {
+		t.Errorf("Expected CDF(median) to be %v, got %v", 0.5, cdf)
+	}
+	if cdf := h.CDF(22); !approx(cdf, 0.75) {
+		t.Errorf("Expected CDF(3rd quartile) to be %v, got %v", 0.75, cdf)
+	}
+}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -12,7 +12,7 @@ func TestHistogramBytes(t *testing.T) {
 	bq := h.Bytes()
 	h = NewHistogramBytes(bq)
 	if h.Count() != 14999 {
-		t.Errorf("Expected h.Count() to be 100, got ", h.Count())
+		t.Errorf("Expected h.Count() to be 14999, got %f", h.Count())
 	}
 
 	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {


### PR DESCRIPTION
My main contribution is a benchmark to quantify the proposed performance enhancements by @nemothekid

```
Before:
< go test -run none -bench . -benchtime 2s
PASS
BenchmarkNumericHistogram20-8    3000000               891 ns/op
BenchmarkNumericHistogram50-8    2000000              1396 ns/op
BenchmarkNumericHistogram100-8   1000000              2120 ns/op
ok      github.com/signalfx/gohistogram 9.901s

After:
< go test -run none -bench . -benchtime 2s
PASS
BenchmarkNumericHistogram20-8   20000000               205 ns/op
BenchmarkNumericHistogram50-8   10000000               340 ns/op
BenchmarkNumericHistogram100-8   5000000               482 ns/op
ok      github.com/signalfx/gohistogram 10.964s
```
