### PR TITLE
Added String() function to the histogram interface + small documentation / test cleanup

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -11,6 +11,10 @@ type Histogram interface {
 
 	// Quantile returns an approximation.
 	Quantile(n float64) (q float64)
+
+	// String returns a string reprentation of the histogram,
+	// which is useful for printing to a terminal.
+	String() (str string)
 }
 
 type bin struct {

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -18,7 +18,7 @@ func TestHistogram(t *testing.T) {
 		h.Add(float64(val))
 	}
 	if h.Count() != 14999 {
-		t.Errorf("Expected h.Count() to be 100, got ", h.Count())
+		t.Errorf("Expected h.Count() to be 14999, got %v", h.Count())
 	}
 
 	if firstQ := h.Quantile(0.25); !approx(firstQ, 14) {

--- a/weightedhistogram.go
+++ b/weightedhistogram.go
@@ -16,7 +16,7 @@ type WeightedHistogram struct {
 	alpha   float64
 }
 
-// NewHistogram returns a new NumericHistogram with a maximum of n bins with a decay factor
+// NewHistogram returns a new WeightedHistogram with a maximum of n bins with a decay factor
 // of alpha.
 //
 // There is no "optimal" bin count, but somewhere between 20 and 80 bins should be

--- a/weightedhistogram.go
+++ b/weightedhistogram.go
@@ -16,7 +16,7 @@ type WeightedHistogram struct {
 	alpha   float64
 }
 
-// NewHistogram returns a new WeightedHistogram with a maximum of n bins with a decay factor
+// NewWeightedHistogram returns a new WeightedHistogram with a maximum of n bins with a decay factor
 // of alpha.
 //
 // There is no "optimal" bin count, but somewhere between 20 and 80 bins should be


### PR DESCRIPTION
This allows to call String() directly on the interface and allows for easier debugging of code that uses both histogram types.